### PR TITLE
Add support for AWS Fargate metadata

### DIFF
--- a/lib/new_relic/util/fargate.ex
+++ b/lib/new_relic/util/fargate.ex
@@ -1,0 +1,25 @@
+defmodule NewRelic.Util.Vendor.Fargate do
+  @fargate_data ["Cluster", "ImageID", "ImageName", "ContainerID", "ContainerName"]
+  @fargate_metadata_env "ECS_CONTAINER_METADATA_FILE"
+
+  def fargate_hash(util, file_path \\ fargate_metadata_file_path()) do
+    case File.read(file_path) do
+      {:ok, metadata_file_content} ->
+        fields =
+          Jason.decode!(metadata_file_content)
+          |> Map.take(@fargate_data)
+
+        Map.put(util, :vendors, %{aws: fields})
+
+      _error ->
+        util
+    end
+  rescue
+    exception ->
+      NewRelic.log(:error, "Failed to fetch Fargate metadata file. #{inspect(exception)}")
+      util
+  end
+
+  defp fargate_metadata_file_path,
+    do: System.get_env(@fargate_metadata_env)
+end

--- a/test/fargate-metadata.json
+++ b/test/fargate-metadata.json
@@ -1,0 +1,27 @@
+{
+  "Cluster": "default",
+  "ContainerInstanceARN": "arn:aws:ecs:us-west-2:012345678910:container-instance/1f73d099-b914-411c-a9ff-81633b7741dd",
+  "TaskARN": "arn:aws:ecs:us-west-2:012345678910:task/2b88376d-aba3-4950-9ddf-bcb0f388a40c",
+  "ContainerID": "98e44444008169587b826b4cd76c6732e5899747e753af1e19a35db64f9e9c32",
+  "ContainerName": "metadata",
+  "DockerContainerName": "/ecs-metadata-7-metadata-f0edfbd6d09fdef20800",
+  "ImageID": "sha256:c24f66af34b4d76558f7743109e2476b6325fcf6cc167c6e1e07cd121a22b341",
+  "ImageName": "httpd:2.4",
+  "PortMappings": [
+    {
+      "ContainerPort": 80,
+      "HostPort": 80,
+      "BindIp": "",
+      "Protocol": "tcp"
+    }
+  ],
+  "Networks": [
+    {
+      "NetworkMode": "bridge",
+      "IPv4Addresses": [
+        "172.17.0.2"
+      ]
+    }
+  ],
+  "MetadataFileStatus": "READY"
+}

--- a/test/fargate_test.exs
+++ b/test/fargate_test.exs
@@ -1,0 +1,58 @@
+defmodule FargateTest do
+  use ExUnit.Case
+  alias NewRelic.Util.Vendor.Fargate
+
+  @test_metadata_path "test/fargate-metadata.json"
+
+  describe "fargate_hash" do
+    test "when a path to the metadata file is provided" do
+      util = Fargate.fargate_hash(%{}, @test_metadata_path)
+
+      assert get_in(util, [:vendors, :aws, "Cluster"]) == "default"
+
+      assert get_in(util, [:vendors, :aws, "ImageID"]) ==
+               "sha256:c24f66af34b4d76558f7743109e2476b6325fcf6cc167c6e1e07cd121a22b341"
+
+      assert get_in(util, [:vendors, :aws, "ImageName"]) == "httpd:2.4"
+
+      assert get_in(util, [:vendors, :aws, "ContainerID"]) ==
+               "98e44444008169587b826b4cd76c6732e5899747e753af1e19a35db64f9e9c32"
+
+      assert get_in(util, [:vendors, :aws, "ContainerName"]) == "metadata"
+    end
+
+    test "when file does not exist" do
+      initial_util = %{key: "value"}
+
+      util = Fargate.fargate_hash(initial_util, "non-exisiting-path")
+
+      assert util == initial_util
+    end
+
+    test "when ECS_CONTAINER_METADATA_FILE is set to an existing file path" do
+      System.put_env("ECS_CONTAINER_METADATA_FILE", @test_metadata_path)
+
+      util = Fargate.fargate_hash(%{})
+
+      assert get_in(util, [:vendors, :aws, "Cluster"]) == "default"
+
+      assert get_in(util, [:vendors, :aws, "ImageID"]) ==
+               "sha256:c24f66af34b4d76558f7743109e2476b6325fcf6cc167c6e1e07cd121a22b341"
+
+      assert get_in(util, [:vendors, :aws, "ImageName"]) == "httpd:2.4"
+
+      assert get_in(util, [:vendors, :aws, "ContainerID"]) ==
+               "98e44444008169587b826b4cd76c6732e5899747e753af1e19a35db64f9e9c32"
+
+      assert get_in(util, [:vendors, :aws, "ContainerName"]) == "metadata"
+    end
+
+    test "when ECS_CONTAINER_METADATA_FILE is set to a non existing file path" do
+      System.put_env("ECS_CONTAINER_METADATA_FILE", "non-exisiting-path")
+
+      util = Fargate.fargate_hash(%{})
+
+      assert util == %{}
+    end
+  end
+end


### PR DESCRIPTION
Adds support for the New Relic agent to be able to collect Fargate related metadata.

More info about where metadata is stored here:
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html
